### PR TITLE
Add task links and board context to /mytasks

### DIFF
--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -80,7 +80,26 @@ describe("formatCardList", () => {
     const result = formatCardList(cards);
     expect(result).toContain("1.");
     expect(result).toContain("Test Task");
-    expect(result).toContain("abc123");
+    expect(result).toContain("Board 1");
+    expect(result).toContain("To Do");
+  });
+
+  it("links task titles to Kan when workspaceSlug is provided", () => {
+    const cards = [
+      {
+        card: {
+          publicId: "abc123",
+          title: "Test Task",
+          dueDate: null,
+          members: [],
+        } as any,
+        board: { name: "Board 1", slug: "board-1" } as any,
+        list: { name: "To Do" } as any,
+      },
+    ];
+    const result = formatCardList(cards, { workspaceSlug: "my-workspace" });
+    expect(result).toContain("[Test Task](https://tasks.xdeca.com/my-workspace/board-1?card=abc123)");
+    expect(result).toContain("Board 1");
     expect(result).toContain("To Do");
   });
 });

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -72,7 +72,10 @@ export function formatCardList(
       const dueInfo = item.card.dueDate
         ? ` - ${formatDueDate(item.card.dueDate)}`
         : "";
-      return `${index + 1}. *${escapeMarkdown(item.card.title)}*${dueInfo}\n   \`${item.card.publicId}\` in ${escapeMarkdown(item.list.name)}`;
+      const title = options.workspaceSlug
+        ? `[${escapeMarkdown(item.card.title)}](${KAN_BASE_URL}/${options.workspaceSlug}/${item.board.slug}?card=${item.card.publicId})`
+        : `*${escapeMarkdown(item.card.title)}*`;
+      return `${index + 1}. ${title}${dueInfo}\n   ${escapeMarkdown(item.board.name)} › ${escapeMarkdown(item.list.name)}`;
     })
     .join("\n\n");
 }


### PR DESCRIPTION
## Summary
- Task titles in `/mytasks` are now clickable links to the Kan task
- Each task shows board and list context (e.g. `Board Name › List Name`)

## Test plan
- [x] 36 tests pass
- [ ] `/mytasks` shows clickable links and board context in Telegram

🤖 Generated with [Claude Code](https://claude.com/claude-code)