### PR TITLE
Fix Kan task URLs to use /boards/:publicId

### DIFF
--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -64,7 +64,7 @@ describe("formatCardList", () => {
     expect(formatCardList([])).toBe("No tasks found.");
   });
 
-  it("formats cards with numbering", () => {
+  it("formats cards with links, board context, and numbering", () => {
     const cards = [
       {
         card: {
@@ -73,32 +73,13 @@ describe("formatCardList", () => {
           dueDate: null,
           members: [],
         } as any,
-        board: { name: "Board 1", slug: "board-1" } as any,
+        board: { name: "Board 1", slug: "board-1", publicId: "5vv5t6f11f5h" } as any,
         list: { name: "To Do" } as any,
       },
     ];
     const result = formatCardList(cards);
     expect(result).toContain("1.");
-    expect(result).toContain("Test Task");
-    expect(result).toContain("Board 1");
-    expect(result).toContain("To Do");
-  });
-
-  it("links task titles to Kan when workspaceSlug is provided", () => {
-    const cards = [
-      {
-        card: {
-          publicId: "abc123",
-          title: "Test Task",
-          dueDate: null,
-          members: [],
-        } as any,
-        board: { name: "Board 1", slug: "board-1" } as any,
-        list: { name: "To Do" } as any,
-      },
-    ];
-    const result = formatCardList(cards, { workspaceSlug: "my-workspace" });
-    expect(result).toContain("[Test Task](https://tasks.xdeca.com/my-workspace/board-1?card=abc123)");
+    expect(result).toContain("[Test Task](https://tasks.xdeca.com/boards/5vv5t6f11f5h)");
     expect(result).toContain("Board 1");
     expect(result).toContain("To Do");
   });

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -50,7 +50,7 @@ export function formatCard(
   }
 
   if (options.includeLink && options.workspaceSlug) {
-    const url = `${KAN_BASE_URL}/${options.workspaceSlug}/${board.slug}?card=${card.publicId}`;
+    const url = `${KAN_BASE_URL}/boards/${board.publicId}`;
     text += `[View in Kan](${url})\n`;
   }
 
@@ -72,9 +72,7 @@ export function formatCardList(
       const dueInfo = item.card.dueDate
         ? ` - ${formatDueDate(item.card.dueDate)}`
         : "";
-      const title = options.workspaceSlug
-        ? `[${escapeMarkdown(item.card.title)}](${KAN_BASE_URL}/${options.workspaceSlug}/${item.board.slug}?card=${item.card.publicId})`
-        : `*${escapeMarkdown(item.card.title)}*`;
+      const title = `[${escapeMarkdown(item.card.title)}](${KAN_BASE_URL}/boards/${item.board.publicId})`;
       return `${index + 1}. ${title}${dueInfo}\n   ${escapeMarkdown(item.board.name)} › ${escapeMarkdown(item.list.name)}`;
     })
     .join("\n\n");
@@ -106,7 +104,7 @@ export function formatOverdueReminder(
     text += `${mentions} `;
   }
 
-  const url = `${KAN_BASE_URL}/${workspaceSlug}/${board.slug}?card=${card.publicId}`;
+  const url = `${KAN_BASE_URL}/boards/${board.publicId}`;
   text += `[View task](${url})`;
 
   return text;
@@ -131,7 +129,7 @@ export function formatNoDueDateReminder(
     text += `When should this be done\\?\n\n`;
   }
 
-  const url = `${KAN_BASE_URL}/${workspaceSlug}/${board.slug}?card=${card.publicId}`;
+  const url = `${KAN_BASE_URL}/boards/${board.publicId}`;
   text += `[View task](${url})`;
 
   return text;
@@ -163,7 +161,7 @@ export function formatVagueTaskReminder(
     text += `This task needs more detail\\.\n\n`;
   }
 
-  const url = `${KAN_BASE_URL}/${workspaceSlug}/${board.slug}?card=${card.publicId}`;
+  const url = `${KAN_BASE_URL}/boards/${board.publicId}`;
   text += `[View task](${url})`;
 
   return text;
@@ -190,7 +188,7 @@ export function formatStaleTaskReminder(
     text += `This task may be blocked\\.\n\n`;
   }
 
-  const url = `${KAN_BASE_URL}/${workspaceSlug}/${board.slug}?card=${card.publicId}`;
+  const url = `${KAN_BASE_URL}/boards/${board.publicId}`;
   text += `[View task](${url})`;
 
   return text;
@@ -213,7 +211,7 @@ export function formatUnassignedReminder(
     text += `Who's working on this\\?\n\n`;
   }
 
-  const url = `${KAN_BASE_URL}/${workspaceSlug}/${board.slug}?card=${card.publicId}`;
+  const url = `${KAN_BASE_URL}/boards/${board.publicId}`;
   text += `[View task](${url})`;
 
   return text;


### PR DESCRIPTION
## Summary
- All task URLs were broken — using `/:workspaceSlug/:boardSlug?card=:cardId` pattern which doesn't resolve
- Fixed to use correct `/boards/:boardPublicId` pattern across all format functions
- Task title links in `/mytasks` no longer depend on `workspaceSlug` option

## Test plan
- [x] 35 tests pass
- [ ] `/mytasks` links open correct board in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)