### PR TITLE
Link board name to board in /mytasks output

### DIFF
--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -80,7 +80,7 @@ describe("formatCardList", () => {
     const result = formatCardList(cards);
     expect(result).toContain("1.");
     expect(result).toContain("[Test Task](https://tasks.xdeca.com/cards/abc123)");
-    expect(result).toContain("Board 1");
+    expect(result).toContain("[Board 1](https://tasks.xdeca.com/boards/5vv5t6f11f5h)");
     expect(result).toContain("To Do");
   });
 });

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -73,7 +73,8 @@ export function formatCardList(
         ? ` - ${formatDueDate(item.card.dueDate)}`
         : "";
       const title = `[${escapeMarkdown(item.card.title)}](${KAN_BASE_URL}/cards/${item.card.publicId})`;
-      return `${index + 1}. ${title}${dueInfo}\n   ${escapeMarkdown(item.board.name)} › ${escapeMarkdown(item.list.name)}`;
+      const boardLink = `[${escapeMarkdown(item.board.name)}](${KAN_BASE_URL}/boards/${item.board.publicId})`;
+      return `${index + 1}. ${title}${dueInfo}\n   ${boardLink} › ${escapeMarkdown(item.list.name)}`;
     })
     .join("\n\n");
 }


### PR DESCRIPTION
## Summary
- Board name in the context line is now a clickable link to the board

## Test plan
- [x] 35 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)