### PR TITLE
Skip Backlog tasks in reminders

### DIFF
--- a/src/api/kan-client.ts
+++ b/src/api/kan-client.ts
@@ -191,12 +191,13 @@ class KanApiClient {
       const fullBoard = await this.getBoard(board.publicId);
 
       for (const list of fullBoard.lists || []) {
-        // Skip lists that appear to be "done" or "archive" lists
+        // Skip lists that appear to be "done", "archive", or "backlog" lists
         const listNameLower = list.name.toLowerCase();
         if (
           listNameLower.includes("done") ||
           listNameLower.includes("complete") ||
-          listNameLower.includes("archive")
+          listNameLower.includes("archive") ||
+          listNameLower.includes("backlog")
         ) {
           continue;
         }
@@ -225,12 +226,13 @@ class KanApiClient {
       const fullBoard = await this.getBoard(board.publicId);
 
       for (const list of fullBoard.lists || []) {
-        // Skip "done" lists for active task view
+        // Skip "done", "archive", and "backlog" lists for active task view
         const listNameLower = list.name.toLowerCase();
         if (
           listNameLower.includes("done") ||
           listNameLower.includes("complete") ||
-          listNameLower.includes("archive")
+          listNameLower.includes("archive") ||
+          listNameLower.includes("backlog")
         ) {
           continue;
         }


### PR DESCRIPTION
## Summary
- Skip tasks in Backlog lists for overdue, unassigned, no-due-date reminders, and `/mytasks` command
- Vague task reminders intentionally still nag about Backlog items to encourage proper descriptions

## Test plan
- [x] All 35 existing tests pass
- [ ] Verify Backlog tasks no longer trigger overdue/unassigned/no-due-date reminders
- [ ] Verify Backlog tasks still trigger vague task reminders
- [ ] Verify `/mytasks` no longer shows Backlog items

🤖 Generated with [Claude Code](https://claude.com/claude-code)