### PR TITLE
fix: correct Claude Haiku model ID

### DIFF
--- a/src/services/vagueness-evaluator.ts
+++ b/src/services/vagueness-evaluator.ts
@@ -31,7 +31,7 @@ export async function evaluateTaskVagueness(task: TaskInfo): Promise<VaguenessRe
 
   try {
     const response = await anthropic.messages.create({
-      model: "claude-haiku-4-20250514",
+      model: "claude-haiku-4-5-20251001",
       max_tokens: 150,
       messages: [
         {


### PR DESCRIPTION
## Summary
- Fixed invalid model ID `claude-haiku-4-20250514` → `claude-haiku-4-5-20251001` in vagueness evaluator
- Was causing 404 errors on every vague task check

## Test plan
- [x] `npm run typecheck` passes
- [ ] Deploy and verify no more 404 model errors in logs

Generated with [Claude Code](https://claude.com/claude-code)