### PR TITLE
feat: reply with @gremlin ☝️ to create task from any message

### DIFF
--- a/src/bot/handlers/message-listener.ts
+++ b/src/bot/handlers/message-listener.ts
@@ -8,6 +8,9 @@ import { storeSuggestion } from "../callbacks/task-suggestion.js";
 
 const INFRA_ASSIGNEE_USERNAME = process.env.INFRA_ASSIGNEE_USERNAME;
 
+/** Emojis that signal "make a task from the message above" */
+const POINT_UP_EMOJIS = /^[\s☝️👆⬆️🔼👆🏻👆🏼👆🏽👆🏾👆🏿☝🏻☝🏼☝🏽☝🏾☝🏿\u{261D}\u{FE0F}]*$/u;
+
 /**
  * Message listener registered via bot.on("message:text").
  * Handles two paths:
@@ -53,14 +56,30 @@ async function handleBotMention(
   botUsername: string | undefined,
   workspacePublicId: string,
 ) {
-  const detection = await detectTask(text);
+  // Check for reply-with-pointer pattern: "@gremlin ☝️" as a reply to another message
+  const replyText = ctx.message?.reply_to_message?.text;
+  const { cleanText: mentionStripped } = extractMentions(text, botUsername);
+  const isPointerReply = !!replyText && POINT_UP_EMOJIS.test(mentionStripped);
+
+  // Use the replied-to message text for task detection if pointing up at it,
+  // otherwise use the @mention message itself
+  const taskSourceText = isPointerReply ? replyText : text;
+
+  const detection = await detectTask(taskSourceText);
 
   // If the LLM says it's not a task, silently ignore
   if (!detection.isTask) return;
 
   try {
-    // Resolve @mentions from the message (excluding bot username)
+    // Resolve @mentions — from the mention message (for assignees like @nick)
+    // and from the replied-to message (if pointer reply)
     const { usernames } = extractMentions(text, botUsername);
+    if (isPointerReply) {
+      const replyMentions = extractMentions(replyText, botUsername);
+      for (const u of replyMentions.usernames) {
+        if (!usernames.includes(u)) usernames.push(u);
+      }
+    }
     const { resolved, unresolved } = await resolveMentionsToMembers(usernames);
     const memberPublicIds = resolved.map((r) => r.memberPublicId);
     const memberNames = resolved.map((r) => `@${r.username}`);


### PR DESCRIPTION
## Summary
- Reply to any message with `@gremlin ☝️` (or 👆⬆️🔼) to create a task from the replied-to message
- The bot sends the replied-to text through LLM task detection and starts the interactive picker flow
- @mentions from both the reply message and the original message are merged for assignee resolution

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run test` — 77 tests pass
- [ ] Reply to a message with `@gremlin ☝️` → creates task from replied-to text
- [ ] Reply with `@gremlin ☝️ @nick` → creates task with @nick assigned
- [ ] `@gremlin create a task to fix login` (not a reply) → still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)