### PR TITLE
chore: upgrade model to Claude Sonnet 4.6

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -5,7 +5,7 @@ import { buildSystemPrompt } from "./system-prompt.js";
 import { getHistory, appendToHistory } from "./conversation-history.js";
 import { getAnthropicClient } from "../services/anthropic-client.js";
 
-const MODEL = "claude-sonnet-4-5-20250929";
+const MODEL = "claude-sonnet-4-6-20250514";
 const MAX_TOOL_ROUNDS = 10;
 const MAX_TOKENS = 2048;
 

--- a/src/services/vagueness-evaluator.ts
+++ b/src/services/vagueness-evaluator.ts
@@ -30,7 +30,7 @@ export async function evaluateTaskVagueness(task: TaskInfo): Promise<VaguenessRe
   try {
     const anthropic = await getAnthropicClient();
     const response = await anthropic.messages.create({
-      model: "claude-sonnet-4-5-20250929",
+      model: "claude-sonnet-4-6-20250514",
       max_tokens: 150,
       messages: [
         {


### PR DESCRIPTION
## Summary
- Upgrade model from Sonnet 4.5 to Sonnet 4.6 in agent loop and vagueness evaluator

## Test plan
- [x] Typecheck passes
- [x] All 33 tests pass

Generated with [Claude Code](https://claude.com/claude-code)