### PR TITLE
feat: require @mention in non-primary topics

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -125,10 +125,16 @@ bot.on("message:text", async (ctx) => {
     ctx.me?.id
   )) return;
 
-  // In groups with a configured topic, only process messages from that topic
+  // In groups with a configured topic:
+  // - In the configured topic (Project Management): process normally (all messages)
+  // - In other topics: only process @mentions and replies to the bot
   if (ctx.chat.type !== "private") {
     const configuredTopic = await getConfiguredTopicId(chatId);
-    if (configuredTopic && ctx.message?.message_thread_id !== configuredTopic) return;
+    if (configuredTopic && ctx.message?.message_thread_id !== configuredTopic) {
+      const isMentioned = botUsername && text.toLowerCase().includes(`@${botUsername.toLowerCase()}`);
+      const isReplyToBot = ctx.me?.id && ctx.message?.reply_to_message?.from?.id === ctx.me.id;
+      if (!isMentioned && !isReplyToBot) return;
+    }
   }
 
   // Track last agent call for cooldown


### PR DESCRIPTION
## Summary
- In group chats, the bot now requires an @mention or reply-to-bot in topics other than the configured primary topic (Project Management)
- The primary topic retains full responsiveness to all messages as before
- Small change to `shouldSkipMessage` flow in `src/index.ts`

## Test plan
- [x] All 62 existing tests pass
- [x] Typecheck passes
- [ ] Manual verification: send a message in a non-PM topic without @mentioning — bot should not respond
- [ ] Manual verification: @mention the bot in a non-PM topic — bot should respond
- [ ] Manual verification: send a message in Project Management topic — bot responds as before

Generated with [Claude Code](https://claude.com/claude-code)