### PR TITLE
fix: fall back to plain text when Telegram rejects Markdown

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -155,13 +155,26 @@ bot.on("message:text", async (ctx) => {
     });
 
     if (response) {
-      await ctx.reply(response, {
-        parse_mode: "Markdown",
-        link_preview_options: { is_disabled: true },
+      const replyOpts = {
+        link_preview_options: { is_disabled: true } as const,
         ...(ctx.message?.message_thread_id
           ? { message_thread_id: ctx.message.message_thread_id }
           : {}),
-      });
+      };
+      try {
+        await ctx.reply(response, { parse_mode: "Markdown", ...replyOpts });
+      } catch (markdownError: unknown) {
+        // If Telegram can't parse the Markdown, fall back to plain text
+        const isParseError =
+          markdownError instanceof Error &&
+          markdownError.message.includes("can't parse entities");
+        if (isParseError) {
+          console.warn("Markdown parse failed, falling back to plain text");
+          await ctx.reply(response, replyOpts);
+        } else {
+          throw markdownError;
+        }
+      }
     }
   } catch (error) {
     console.error("Agent loop error:", error);


### PR DESCRIPTION
## Summary
- When the LLM generates responses with unmatched Markdown entities (`*`, `_`, etc.), Telegram's legacy Markdown v1 parser returns a 400 "can't parse entities" error
- Previously this caused the generic "Something went wrong" fallback — users lost the entire response
- Now catches the parse error and retries the same message as plain text, so users always get the response (just without formatting)

## Test plan
- [x] All 62 existing tests pass
- [x] TypeScript type check passes
- [ ] Send a message that triggers an LLM response with unmatched Markdown — should degrade to plain text instead of erroring

Generated with [Claude Code](https://claude.com/claude-code)