### PR TITLE
feat: token auth error alerts and proactive health checks

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -3,7 +3,11 @@ import type { Api } from "grammy";
 import { getAnthropicTools, executeTool } from "./tool-registry.js";
 import { buildSystemPrompt } from "./system-prompt.js";
 import { getHistory, appendToHistory } from "./conversation-history.js";
-import { getAnthropicClient } from "../services/anthropic-client.js";
+import {
+  getAnthropicClient,
+  invalidateCachedClient,
+} from "../services/anthropic-client.js";
+import { alertAdmins } from "../services/admin-alerts.js";
 
 const MODEL = "claude-sonnet-4-6";
 const MAX_TOOL_ROUNDS = 10;
@@ -21,6 +25,19 @@ interface AgentInput {
 }
 
 /**
+ * Check whether an error is an Anthropic API auth failure (401).
+ * The SDK throws errors with a `status` property for HTTP-level failures.
+ */
+function isApiAuthError(err: unknown): boolean {
+  return (
+    err != null &&
+    typeof err === "object" &&
+    "status" in err &&
+    (err as { status: number }).status === 401
+  );
+}
+
+/**
  * Run the agent loop: send message to Claude, execute tool calls, return final text.
  * Sends typing indicators while working.
  */
@@ -28,7 +45,15 @@ export async function runAgentLoop(
   api: Api,
   input: AgentInput
 ): Promise<string> {
-  const anthropic = await getAnthropicClient();
+  let anthropic: Anthropic;
+  try {
+    anthropic = await getAnthropicClient();
+  } catch (err) {
+    // getAnthropicClient already logs and alerts admins
+    console.error("Failed to get Anthropic client:", err);
+    return "I'm having trouble with my brain connection right now. The team has been notified.";
+  }
+
   const tools = getAnthropicTools();
   const systemPrompt = await buildSystemPrompt({
     chatId: input.chatId,
@@ -58,13 +83,28 @@ export async function runAgentLoop(
   while (rounds < MAX_TOOL_ROUNDS) {
     rounds++;
 
-    response = await anthropic.messages.create({
-      model: MODEL,
-      max_tokens: MAX_TOKENS,
-      system: systemPrompt,
-      tools,
-      messages,
-    });
+    try {
+      response = await anthropic.messages.create({
+        model: MODEL,
+        max_tokens: MAX_TOKENS,
+        system: systemPrompt,
+        tools,
+        messages,
+      });
+    } catch (err) {
+      if (isApiAuthError(err)) {
+        // Access token rejected mid-session — force re-auth on next call
+        console.error("Anthropic API returned 401 during messages.create:", err);
+        invalidateCachedClient();
+        alertAdmins(
+          "token_auth",
+          "Access token rejected by Anthropic API during a conversation. Client cache invalidated — next request will attempt re-auth."
+        );
+        return "I'm having trouble with my brain connection right now. The team has been notified.";
+      }
+      // Non-auth API error — let it propagate to the outer catch in index.ts
+      throw err;
+    }
 
     // Check if there are tool calls
     const toolUseBlocks = response.content.filter(

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { registerDeployInfoTools } from "./tools/deploy-info.js";
 import { startTaskChecker } from "./scheduler/task-checker.js";
 import { startStandupChecker } from "./scheduler/standup-checker.js";
 import { startCalendarChecker } from "./scheduler/calendar-checker.js";
+import { startTokenHealthChecker } from "./scheduler/token-health.js";
 
 // Admin check
 const ADMIN_USER_IDS: Set<number> = new Set(
@@ -220,6 +221,9 @@ async function main() {
 
   // Start the calendar checker (event reminders at 24h, 1h, 15m)
   startCalendarChecker(bot);
+
+  // Start the token health checker (proactive auth validation every 4h)
+  startTokenHealthChecker();
 
   // Start polling
   console.log("Starting polling...");

--- a/src/scheduler/token-health.ts
+++ b/src/scheduler/token-health.ts
@@ -1,0 +1,34 @@
+import cron from "node-cron";
+import { getAnthropicClient, getTokenHealth } from "../services/anthropic-client.js";
+
+/**
+ * Periodic token health checker.
+ * Runs every 4 hours to proactively verify the OAuth refresh token works.
+ * If the refresh fails, getAnthropicClient() fires admin alerts automatically.
+ */
+export function startTokenHealthChecker(): void {
+  console.log("Starting token health checker (every 4 hours)");
+
+  cron.schedule("0 */4 * * *", async () => {
+    console.log("Running token health check...");
+    await checkTokenHealth();
+  });
+
+  // Run once on startup after a short delay (after MCP init)
+  setTimeout(() => {
+    console.log("Running initial token health check...");
+    checkTokenHealth();
+  }, 10_000);
+}
+
+async function checkTokenHealth(): Promise<void> {
+  try {
+    await getAnthropicClient();
+    const health = getTokenHealth();
+    const expiresIn = Math.round((health.expiresAt - Date.now()) / (1000 * 60 * 60));
+    console.log(`Token health: ${health.status}, expires in ~${expiresIn}h`);
+  } catch (err) {
+    // getAnthropicClient already logs and alerts admins — just log the health check failure
+    console.error("Token health check failed:", err instanceof Error ? err.message : err);
+  }
+}

--- a/src/services/admin-alerts.ts
+++ b/src/services/admin-alerts.ts
@@ -1,0 +1,74 @@
+/**
+ * Admin alert service — sends Telegram DMs directly to admin user IDs.
+ * Uses raw fetch() against the Telegram Bot API (no Grammy dependency)
+ * so alerts work even if the bot framework is down.
+ */
+
+const TELEGRAM_API = "https://api.telegram.org";
+const RATE_LIMIT_MS = 60 * 60 * 1000; // 1 alert per type per hour
+
+/** Tracks the last alert timestamp per alert type to prevent spam. */
+const lastAlertAt = new Map<string, number>();
+
+/** Parse admin user IDs from env once. */
+function getAdminUserIds(): number[] {
+  return (process.env.ADMIN_USER_IDS || "")
+    .split(",")
+    .map((id) => parseInt(id.trim(), 10))
+    .filter((id) => !isNaN(id));
+}
+
+/**
+ * Send an alert message to all admin users via Telegram DM.
+ * Rate-limited: at most 1 alert per `alertType` per hour.
+ * Fire-and-forget — logs to console.error if Telegram send fails.
+ */
+export async function alertAdmins(
+  alertType: string,
+  message: string
+): Promise<void> {
+  // Rate limit check
+  const now = Date.now();
+  const lastSent = lastAlertAt.get(alertType);
+  if (lastSent && now - lastSent < RATE_LIMIT_MS) {
+    return;
+  }
+
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  if (!token) {
+    console.error(`[admin-alert] No TELEGRAM_BOT_TOKEN, cannot send alert: ${message}`);
+    return;
+  }
+
+  const adminIds = getAdminUserIds();
+  if (adminIds.length === 0) {
+    console.error(`[admin-alert] No ADMIN_USER_IDS configured, cannot send alert: ${message}`);
+    return;
+  }
+
+  // Mark as sent before attempting (prevents retry storms on slow networks)
+  lastAlertAt.set(alertType, now);
+
+  const fullMessage = `⚠️ *Bot Alert* (${alertType})\n\n${message}`;
+
+  for (const chatId of adminIds) {
+    try {
+      const res = await fetch(`${TELEGRAM_API}/bot${token}/sendMessage`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          chat_id: chatId,
+          text: fullMessage,
+          parse_mode: "Markdown",
+        }),
+      });
+
+      if (!res.ok) {
+        const body = await res.text();
+        console.error(`[admin-alert] Failed to DM admin ${chatId}: ${res.status} ${body}`);
+      }
+    } catch (err) {
+      console.error(`[admin-alert] Failed to DM admin ${chatId}:`, err);
+    }
+  }
+}

--- a/src/services/anthropic-client.ts
+++ b/src/services/anthropic-client.ts
@@ -1,5 +1,6 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { getOAuthToken, saveOAuthToken } from "../db/queries.js";
+import { alertAdmins } from "./admin-alerts.js";
 
 const TOKEN_URL = "https://console.anthropic.com/v1/oauth/token";
 const CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"; // Claude Code CLI
@@ -8,6 +9,8 @@ const REFRESH_BUFFER_MS = 60 * 60 * 1000; // Refresh 1 hour before expiry
 let cachedClient: Anthropic | null = null;
 let tokenExpiresAt = 0;
 let currentRefreshToken: string | null = null; // Refresh tokens are single-use
+let lastSuccessfulRefresh = 0;
+let lastRefreshError: string | null = null;
 
 interface TokenResponse {
   access_token: string;
@@ -15,11 +18,70 @@ interface TokenResponse {
   expires_in: number; // seconds (typically 28800 = 8h)
 }
 
+export interface TokenHealth {
+  status: "healthy" | "expired" | "error" | "unknown";
+  lastRefresh: number; // epoch ms, 0 if never refreshed
+  expiresAt: number; // epoch ms, 0 if unknown
+  error?: string;
+}
+
+/** Returns current token health status for diagnostics and health checks. */
+export function getTokenHealth(): TokenHealth {
+  if (lastRefreshError) {
+    return {
+      status: "error",
+      lastRefresh: lastSuccessfulRefresh,
+      expiresAt: tokenExpiresAt,
+      error: lastRefreshError,
+    };
+  }
+
+  if (lastSuccessfulRefresh === 0) {
+    return {
+      status: "unknown",
+      lastRefresh: 0,
+      expiresAt: 0,
+    };
+  }
+
+  if (Date.now() >= tokenExpiresAt) {
+    return {
+      status: "expired",
+      lastRefresh: lastSuccessfulRefresh,
+      expiresAt: tokenExpiresAt,
+    };
+  }
+
+  return {
+    status: "healthy",
+    lastRefresh: lastSuccessfulRefresh,
+    expiresAt: tokenExpiresAt,
+  };
+}
+
+/** Force the next getAnthropicClient() call to re-authenticate. */
+export function invalidateCachedClient(): void {
+  cachedClient = null;
+  tokenExpiresAt = 0;
+}
+
+/**
+ * Classify an OAuth refresh error by HTTP status.
+ * Returns true if the error is an auth failure (unrecoverable).
+ */
+function isAuthError(status: number): boolean {
+  return status === 401 || status === 403;
+}
+
 /**
  * Get an Anthropic client authenticated via Claude Max OAuth.
  * Caches the client and auto-refreshes the access token before expiry.
  * Refresh tokens are single-use — each refresh returns a new one.
  * Persists the latest refresh token to SQLite so it survives restarts.
+ *
+ * On failure, classifies errors and alerts admins:
+ * - 401/403: Auth failure (token revoked/invalid) → "token_auth" alert
+ * - Other HTTP/network errors: Transient failure → "token_network" alert
  */
 export async function getAnthropicClient(): Promise<Anthropic> {
   if (cachedClient && Date.now() < tokenExpiresAt - REFRESH_BUFFER_MS) {
@@ -38,27 +100,65 @@ export async function getAnthropicClient(): Promise<Anthropic> {
   refreshToken ??= process.env.CLAUDE_REFRESH_TOKEN ?? null;
 
   if (!refreshToken) {
-    throw new Error("No refresh token available (checked DB and CLAUDE_REFRESH_TOKEN env var)");
+    const msg = "No refresh token available (checked DB and CLAUDE_REFRESH_TOKEN env var)";
+    lastRefreshError = msg;
+    throw new Error(msg);
   }
 
-  const res = await fetch(TOKEN_URL, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      grant_type: "refresh_token",
-      refresh_token: refreshToken,
-      client_id: CLIENT_ID,
-    }),
-  });
+  let res: Response;
+  try {
+    res = await fetch(TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+        client_id: CLIENT_ID,
+      }),
+    });
+  } catch (err) {
+    // Network error — endpoint unreachable
+    const msg = `OAuth token refresh network error: ${err instanceof Error ? err.message : String(err)}`;
+    console.error(msg);
+    lastRefreshError = msg;
+    alertAdmins(
+      "token_network",
+      `Failed to reach Anthropic token endpoint.\n\n\`${err instanceof Error ? err.message : String(err)}\``
+    );
+    throw new Error(msg);
+  }
 
   if (!res.ok) {
     const body = await res.text();
-    throw new Error(`OAuth token refresh failed (${res.status}): ${body}`);
+    const truncatedBody = body.length > 200 ? body.slice(0, 200) + "…" : body;
+
+    if (isAuthError(res.status)) {
+      const msg = `OAuth refresh token invalid (${res.status}): ${truncatedBody}`;
+      console.error(msg);
+      lastRefreshError = msg;
+      alertAdmins(
+        "token_auth",
+        `Refresh token rejected by Anthropic (HTTP ${res.status}).\n\nThis likely means the token was revoked, the subscription lapsed, or the single-use token was already consumed without being persisted.\n\n\`${truncatedBody}\``
+      );
+      throw new Error(msg);
+    }
+
+    // Other HTTP error (5xx, rate limit, etc.) — transient
+    const msg = `OAuth token refresh failed (${res.status}): ${truncatedBody}`;
+    console.error(msg);
+    lastRefreshError = msg;
+    alertAdmins(
+      "token_network",
+      `Token refresh failed with HTTP ${res.status}.\n\n\`${truncatedBody}\``
+    );
+    throw new Error(msg);
   }
 
   const data = (await res.json()) as TokenResponse;
   tokenExpiresAt = Date.now() + data.expires_in * 1000;
   currentRefreshToken = data.refresh_token;
+  lastSuccessfulRefresh = Date.now();
+  lastRefreshError = null;
 
   // Persist the new single-use refresh token to DB (expiresAt tracks access token expiry for cache invalidation)
   try {


### PR DESCRIPTION
## Summary
- **Admin alert service** (`admin-alerts.ts`): Sends Telegram DMs to admins via raw `fetch()` (independent of Grammy). Rate-limited to 1 alert per type per hour to prevent spam during sustained failures.
- **Error classification** (`anthropic-client.ts`): OAuth refresh failures are now categorized — 401/403 fires `token_auth` alert (unrecoverable), network/5xx fires `token_network` (transient). Exports `getTokenHealth()` for diagnostics and `invalidateCachedClient()` for mid-session recovery.
- **Agent loop auth handling** (`agent-loop.ts`): Catches auth errors at both `getAnthropicClient()` and `messages.create()`. Users see "brain connection" message instead of generic "Something went wrong". Mid-session 401 invalidates cached client.
- **Proactive health check** (`token-health.ts`): Cron job every 4 hours calls `getAnthropicClient()` to trigger refresh. Catches failures before users hit them. Also runs once on startup.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (62 tests)
- [ ] Simulate refresh failure: set `CLAUDE_REFRESH_TOKEN` to invalid value
  - Verify console logs show clear auth error classification
  - Verify admin DM receives alert
  - Verify user gets "brain connection" message, not generic error
- [ ] Verify rate limiting: trigger multiple failures, confirm only 1 alert per hour

🤖 Generated with [Claude Code](https://claude.com/claude-code)