### PR TITLE
fix(deploy): post arrival messages to Project Management topic

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,6 +99,7 @@ jobs:
           COMMITS=$(git log --oneline -5 --no-merges)
           curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
             -d chat_id="-1002401283379" \
+            -d message_thread_id="101" \
             -d text="🟢 *Gremlin has entered the building.* Deploy successful on \`$(git rev-parse --short HEAD)\`
 
           *Recent changes:*
@@ -113,6 +114,7 @@ jobs:
         run: |
           curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
             -d chat_id="-1002401283379" \
+            -d message_thread_id="101" \
             -d text="🔴 *Gremlin did not make it.* Deploy failed on \`$(git rev-parse --short HEAD)\` — check the logs, something is very wrong." \
             -d parse_mode="Markdown"
 


### PR DESCRIPTION
## Summary

- Add `message_thread_id=101` to deploy success and failure Telegram announcements
- Messages will now land in the Project Management topic instead of General

## Context

The deploy workflow's `curl` calls to the Telegram API were missing the `message_thread_id` parameter. In forum-enabled groups, this causes messages to default to the General topic. The correct thread ID (101) was looked up from the bot's SQLite DB on the server.

## Test plan
- [x] Next deploy will post to Project Management topic instead of General

🤖 Generated with [Claude Code](https://claude.com/claude-code)