### PR TITLE
feat: preserve tool call context in conversation history

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -114,11 +114,10 @@ export async function runAgentLoop(
     if (toolUseBlocks.length === 0) {
       // No tool calls — extract final text and return
       const text = extractText(response.content);
-      const assistantMessage: Anthropic.Messages.MessageParam = {
-        role: "assistant",
-        content: text,
-      };
-      appendToHistory(input.chatId, userMessage, assistantMessage);
+      // Capture the full turn: everything added since history ended
+      const turnMessages = messages.slice(history.length);
+      turnMessages.push({ role: "assistant", content: text });
+      appendToHistory(input.chatId, turnMessages);
       return text;
     }
 
@@ -158,14 +157,14 @@ export async function runAgentLoop(
     messages.push({ role: "user", content: toolResults });
   }
 
-  // Exhausted tool rounds — return whatever text we have
+  // Exhausted tool rounds — cap with text-only assistant message.
+  // Don't store unfulfilled tool_use blocks from response — they'd lack matching tool_results.
   const fallbackText = extractText(response!.content);
-  const assistantMessage: Anthropic.Messages.MessageParam = {
-    role: "assistant",
-    content: fallbackText || "I ran into too many steps trying to complete that. Could you try a simpler request?",
-  };
-  appendToHistory(input.chatId, userMessage, assistantMessage);
-  return assistantMessage.content as string;
+  const cappingText = fallbackText || "I ran into too many steps trying to complete that. Could you try a simpler request?";
+  const turnMessages = messages.slice(history.length);
+  turnMessages.push({ role: "assistant", content: cappingText });
+  appendToHistory(input.chatId, turnMessages);
+  return cappingText;
 }
 
 /** Extract text content from Claude response blocks. */

--- a/src/agent/conversation-history.test.ts
+++ b/src/agent/conversation-history.test.ts
@@ -29,7 +29,7 @@ vi.mock("../db/client.js", async () => {
 
 // These resolve to the mocked in-memory instances
 import { sqlite } from "../db/client.js";
-import { getHistory, appendToHistory, clearHistory } from "./conversation-history.js";
+import { getHistory, appendToHistory, clearHistory, _testOnly } from "./conversation-history.js";
 
 // Use unique chat IDs per test to avoid in-memory cache interference
 let nextChatId = 1000;
@@ -47,11 +47,10 @@ describe("conversation-history", () => {
 
   it("appends and retrieves messages", () => {
     const chatId = nextChatId++;
-    appendToHistory(
-      chatId,
+    appendToHistory(chatId, [
       { role: "user", content: "Hello" },
       { role: "assistant", content: "Hi there" },
-    );
+    ]);
 
     const history = getHistory(chatId);
     expect(history).toHaveLength(2);
@@ -59,31 +58,29 @@ describe("conversation-history", () => {
     expect(history[1]).toEqual({ role: "assistant", content: "Hi there" });
   });
 
-  it("enforces sliding window of 20 messages (10 pairs)", () => {
+  it("enforces sliding window by evicting oldest turns", () => {
     const chatId = nextChatId++;
-    // Append 12 pairs = 24 messages; window keeps last 10 pairs = 20 messages
-    for (let i = 0; i < 12; i++) {
-      appendToHistory(
-        chatId,
+    // Append 25 simple turns = 50 messages; window of 40 keeps last 20 turns
+    for (let i = 0; i < 25; i++) {
+      appendToHistory(chatId, [
         { role: "user", content: `User ${i}` },
         { role: "assistant", content: `Bot ${i}` },
-      );
+      ]);
     }
 
     const history = getHistory(chatId);
-    expect(history).toHaveLength(20);
-    // Pairs 0 and 1 should be evicted — first message is from pair 2
-    expect(history[0]).toEqual({ role: "user", content: "User 2" });
-    expect(history[history.length - 1]).toEqual({ role: "assistant", content: "Bot 11" });
+    expect(history).toHaveLength(40);
+    // Turns 0-4 (10 messages) should be evicted — first message is from turn 5
+    expect(history[0]).toEqual({ role: "user", content: "User 5" });
+    expect(history[history.length - 1]).toEqual({ role: "assistant", content: "Bot 24" });
   });
 
   it("clears history from both cache and DB", () => {
     const chatId = nextChatId++;
-    appendToHistory(
-      chatId,
+    appendToHistory(chatId, [
       { role: "user", content: "Hello" },
       { role: "assistant", content: "Hi" },
-    );
+    ]);
 
     clearHistory(chatId);
 
@@ -103,14 +100,13 @@ describe("conversation-history", () => {
 
   it("writes through to DB on append", () => {
     const chatId = nextChatId++;
-    appendToHistory(
-      chatId,
+    appendToHistory(chatId, [
       { role: "user", content: "Hello" },
       { role: "assistant", content: "Hi" },
-    );
+    ]);
 
     const msgs = sqlite
-      .prepare("SELECT role, content FROM conversation_messages WHERE telegram_chat_id = ? ORDER BY created_at")
+      .prepare("SELECT role, content FROM conversation_messages WHERE telegram_chat_id = ? ORDER BY id")
       .all(chatId) as { role: string; content: string }[];
 
     expect(msgs).toHaveLength(2);
@@ -168,24 +164,424 @@ describe("conversation-history", () => {
   it("trims excess messages in DB beyond window size", () => {
     const chatId = nextChatId++;
 
-    // Append 15 pairs = 30 messages; trim keeps only 20 in DB
-    for (let i = 0; i < 15; i++) {
-      appendToHistory(
-        chatId,
+    // Append 25 simple turns = 50 messages; trim keeps only 40 in DB
+    for (let i = 0; i < 25; i++) {
+      appendToHistory(chatId, [
         { role: "user", content: `Msg ${i}` },
         { role: "assistant", content: `Reply ${i}` },
-      );
+      ]);
     }
 
     const count = sqlite
       .prepare("SELECT COUNT(*) as cnt FROM conversation_messages WHERE telegram_chat_id = ?")
       .get(chatId) as { cnt: number };
-    expect(count.cnt).toBe(20);
+    expect(count.cnt).toBe(40);
 
     // Verify the remaining messages are the most recent ones
     const oldest = sqlite
-      .prepare("SELECT content FROM conversation_messages WHERE telegram_chat_id = ? ORDER BY created_at ASC LIMIT 1")
+      .prepare("SELECT content FROM conversation_messages WHERE telegram_chat_id = ? ORDER BY id ASC LIMIT 1")
       .get(chatId) as { content: string };
     expect(oldest.content).toBe("Msg 5");
+  });
+
+  // ---------------------------------------------------------------------------
+  // New: Tool call context tests
+  // ---------------------------------------------------------------------------
+
+  it("preserves tool call round-trip in history", () => {
+    const chatId = nextChatId++;
+    const turn = [
+      { role: "user" as const, content: "Create a card called Test" },
+      {
+        role: "assistant" as const,
+        content: [
+          {
+            type: "tool_use" as const,
+            id: "toolu_123",
+            name: "kan_create_card",
+            input: { title: "Test", board_id: "abc" },
+          },
+        ],
+      },
+      {
+        role: "user" as const,
+        content: [
+          {
+            type: "tool_result" as const,
+            tool_use_id: "toolu_123",
+            content: '{"publicId":"card_xyz","title":"Test"}',
+          },
+        ],
+      },
+      { role: "assistant" as const, content: "Done! Created card card_xyz." },
+    ];
+
+    appendToHistory(chatId, turn);
+
+    const history = getHistory(chatId);
+    expect(history).toHaveLength(4);
+    expect(history[0]).toEqual({ role: "user", content: "Create a card called Test" });
+    // Assistant tool_use block preserved
+    expect(history[1].role).toBe("assistant");
+    expect(Array.isArray(history[1].content)).toBe(true);
+    const toolUse = (history[1].content as any[])[0];
+    expect(toolUse.type).toBe("tool_use");
+    expect(toolUse.name).toBe("kan_create_card");
+    // User tool_result block preserved
+    expect(history[2].role).toBe("user");
+    expect(Array.isArray(history[2].content)).toBe(true);
+    // Final text
+    expect(history[3]).toEqual({ role: "assistant", content: "Done! Created card card_xyz." });
+  });
+
+  it("serializes structured content to DB as JSON", () => {
+    const chatId = nextChatId++;
+    const turn = [
+      { role: "user" as const, content: "Create a card" },
+      {
+        role: "assistant" as const,
+        content: [
+          {
+            type: "tool_use" as const,
+            id: "toolu_456",
+            name: "kan_create_card",
+            input: { title: "Test" },
+          },
+        ],
+      },
+      {
+        role: "user" as const,
+        content: [
+          {
+            type: "tool_result" as const,
+            tool_use_id: "toolu_456",
+            content: '{"publicId":"card_abc"}',
+          },
+        ],
+      },
+      { role: "assistant" as const, content: "Created card_abc." },
+    ];
+
+    appendToHistory(chatId, turn);
+
+    const rows = sqlite
+      .prepare("SELECT role, content FROM conversation_messages WHERE telegram_chat_id = ? ORDER BY id")
+      .all(chatId) as { role: string; content: string }[];
+
+    expect(rows).toHaveLength(4);
+    // User text stays as plain string
+    expect(rows[0].content).toBe("Create a card");
+    // Assistant tool_use is JSON-serialized
+    expect(rows[1].content.startsWith("[")).toBe(true);
+    const parsed1 = JSON.parse(rows[1].content);
+    expect(parsed1[0].type).toBe("tool_use");
+    // User tool_result is JSON-serialized
+    expect(rows[2].content.startsWith("[")).toBe(true);
+    const parsed2 = JSON.parse(rows[2].content);
+    expect(parsed2[0].type).toBe("tool_result");
+    // Final text stays as plain string
+    expect(rows[3].content).toBe("Created card_abc.");
+  });
+
+  it("deserializes structured content from DB on cache miss", () => {
+    const chatId = nextChatId++;
+    const now = Math.floor(Date.now() / 1000);
+
+    // Insert rows directly with JSON content (simulates restart with tool history)
+    sqlite
+      .prepare("INSERT INTO conversations (telegram_chat_id, created_at, last_activity) VALUES (?, ?, ?)")
+      .run(chatId, now, now);
+
+    const toolUseContent = JSON.stringify([
+      { type: "tool_use", id: "toolu_789", name: "kan_get_card", input: { card_id: "xyz" } },
+    ]);
+    const toolResultContent = JSON.stringify([
+      { type: "tool_result", tool_use_id: "toolu_789", content: '{"title":"My Card"}' },
+    ]);
+
+    sqlite
+      .prepare("INSERT INTO conversation_messages (telegram_chat_id, role, content, created_at) VALUES (?, ?, ?, ?)")
+      .run(chatId, "user", "Show card xyz", now);
+    sqlite
+      .prepare("INSERT INTO conversation_messages (telegram_chat_id, role, content, created_at) VALUES (?, ?, ?, ?)")
+      .run(chatId, "assistant", toolUseContent, now);
+    sqlite
+      .prepare("INSERT INTO conversation_messages (telegram_chat_id, role, content, created_at) VALUES (?, ?, ?, ?)")
+      .run(chatId, "user", toolResultContent, now);
+    sqlite
+      .prepare("INSERT INTO conversation_messages (telegram_chat_id, role, content, created_at) VALUES (?, ?, ?, ?)")
+      .run(chatId, "assistant", "Here is your card: My Card", now);
+
+    const history = getHistory(chatId);
+    expect(history).toHaveLength(4);
+    // Tool use block deserialized to array
+    expect(Array.isArray(history[1].content)).toBe(true);
+    expect((history[1].content as any[])[0].type).toBe("tool_use");
+    // Tool result block deserialized to array
+    expect(Array.isArray(history[2].content)).toBe(true);
+    expect((history[2].content as any[])[0].type).toBe("tool_result");
+  });
+
+  it("truncates large tool results in DB", () => {
+    const chatId = nextChatId++;
+    const largeResult = "x".repeat(2000);
+    const turn = [
+      { role: "user" as const, content: "List all cards" },
+      {
+        role: "assistant" as const,
+        content: [
+          { type: "tool_use" as const, id: "toolu_big", name: "kan_list_cards", input: {} },
+        ],
+      },
+      {
+        role: "user" as const,
+        content: [
+          { type: "tool_result" as const, tool_use_id: "toolu_big", content: largeResult },
+        ],
+      },
+      { role: "assistant" as const, content: "Found many cards." },
+    ];
+
+    appendToHistory(chatId, turn);
+
+    // In-memory cache should still have full content
+    const history = getHistory(chatId);
+    const toolResultMsg = history[2];
+    const toolResultBlock = (toolResultMsg.content as any[])[0];
+    expect(toolResultBlock.content).toBe(largeResult); // Full in memory
+
+    // DB should have truncated content
+    const rows = sqlite
+      .prepare("SELECT content FROM conversation_messages WHERE telegram_chat_id = ? ORDER BY id")
+      .all(chatId) as { content: string }[];
+
+    const dbToolResult = JSON.parse(rows[2].content);
+    expect(dbToolResult[0].content.length).toBeLessThan(largeResult.length);
+    expect(dbToolResult[0].content).toContain("… [truncated]");
+    expect(dbToolResult[0].content.length).toBeLessThanOrEqual(
+      _testOnly.MAX_TOOL_RESULT_LENGTH + "… [truncated]".length
+    );
+  });
+
+  it("evicts complete turns, never orphaning tool_use/tool_result", () => {
+    const chatId = nextChatId++;
+
+    // Add tool turns (4 messages each = fills up faster)
+    for (let i = 0; i < 12; i++) {
+      appendToHistory(chatId, [
+        { role: "user" as const, content: `Do thing ${i}` },
+        {
+          role: "assistant" as const,
+          content: [
+            { type: "tool_use" as const, id: `toolu_${i}`, name: "some_tool", input: {} },
+          ],
+        },
+        {
+          role: "user" as const,
+          content: [
+            { type: "tool_result" as const, tool_use_id: `toolu_${i}`, content: `result ${i}` },
+          ],
+        },
+        { role: "assistant" as const, content: `Done ${i}` },
+      ]);
+    }
+
+    // 12 turns × 4 = 48 messages. Window is 40, so 2 turns evicted → 10 × 4 = 40
+    const history = getHistory(chatId);
+    expect(history.length).toBeLessThanOrEqual(40);
+    // First message should be a user message with string content (start of a turn)
+    expect(history[0].role).toBe("user");
+    expect(typeof history[0].content).toBe("string");
+    // Verify no orphaned tool_result at the start
+    expect((history[0].content as string).startsWith("Do thing")).toBe(true);
+  });
+
+  it("backward compatible with plain text DB rows (old format)", () => {
+    const chatId = nextChatId++;
+    const now = Math.floor(Date.now() / 1000);
+
+    // Insert plain text rows (old format before this change)
+    sqlite
+      .prepare("INSERT INTO conversations (telegram_chat_id, created_at, last_activity) VALUES (?, ?, ?)")
+      .run(chatId, now, now);
+    sqlite
+      .prepare("INSERT INTO conversation_messages (telegram_chat_id, role, content, created_at) VALUES (?, ?, ?, ?)")
+      .run(chatId, "user", "Hello", now);
+    sqlite
+      .prepare("INSERT INTO conversation_messages (telegram_chat_id, role, content, created_at) VALUES (?, ?, ?, ?)")
+      .run(chatId, "assistant", "Hi there!", now);
+
+    const history = getHistory(chatId);
+    expect(history).toHaveLength(2);
+    expect(history[0]).toEqual({ role: "user", content: "Hello" });
+    expect(history[1]).toEqual({ role: "assistant", content: "Hi there!" });
+  });
+
+  it("trims orphaned tool_result at start of DB rows on load", () => {
+    const chatId = nextChatId++;
+    const now = Math.floor(Date.now() / 1000);
+
+    // Simulate a window boundary that cuts mid-turn: starts with orphaned tool_result
+    sqlite
+      .prepare("INSERT INTO conversations (telegram_chat_id, created_at, last_activity) VALUES (?, ?, ?)")
+      .run(chatId, now, now);
+
+    // Orphaned tool_result (no preceding tool_use) — should be trimmed
+    const orphanedContent = JSON.stringify([
+      { type: "tool_result", tool_use_id: "toolu_old", content: "stale result" },
+    ]);
+    sqlite
+      .prepare("INSERT INTO conversation_messages (telegram_chat_id, role, content, created_at) VALUES (?, ?, ?, ?)")
+      .run(chatId, "user", orphanedContent, now);
+    sqlite
+      .prepare("INSERT INTO conversation_messages (telegram_chat_id, role, content, created_at) VALUES (?, ?, ?, ?)")
+      .run(chatId, "assistant", "Based on that result...", now);
+
+    // Then a complete turn
+    sqlite
+      .prepare("INSERT INTO conversation_messages (telegram_chat_id, role, content, created_at) VALUES (?, ?, ?, ?)")
+      .run(chatId, "user", "What is 2+2?", now);
+    sqlite
+      .prepare("INSERT INTO conversation_messages (telegram_chat_id, role, content, created_at) VALUES (?, ?, ?, ?)")
+      .run(chatId, "assistant", "4", now);
+
+    const history = getHistory(chatId);
+    // Orphaned fragment trimmed — only the complete turn remains
+    expect(history).toHaveLength(2);
+    expect(history[0]).toEqual({ role: "user", content: "What is 2+2?" });
+    expect(history[1]).toEqual({ role: "assistant", content: "4" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests for helper functions
+// ---------------------------------------------------------------------------
+
+describe("conversation-history helpers", () => {
+  describe("deserializeContent", () => {
+    it("passes through plain text", () => {
+      expect(_testOnly.deserializeContent("Hello world")).toBe("Hello world");
+    });
+
+    it("parses JSON arrays back to objects", () => {
+      const json = JSON.stringify([{ type: "tool_use", id: "x", name: "y", input: {} }]);
+      const result = _testOnly.deserializeContent(json);
+      expect(Array.isArray(result)).toBe(true);
+      expect((result as any[])[0].type).toBe("tool_use");
+    });
+
+    it("falls back to string for invalid JSON starting with [", () => {
+      expect(_testOnly.deserializeContent("[not valid json")).toBe("[not valid json");
+    });
+
+    it("passes through text that starts with [ but parses to non-array", () => {
+      // This shouldn't normally happen, but test the guard
+      const result = _testOnly.deserializeContent("[invalid");
+      expect(typeof result).toBe("string");
+    });
+  });
+
+  describe("truncateToolResults", () => {
+    it("does not truncate short results", () => {
+      const messages: any[] = [
+        {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "x", content: "short result" },
+          ],
+        },
+      ];
+      const result = _testOnly.truncateToolResults(messages);
+      expect((result[0].content as any[])[0].content).toBe("short result");
+    });
+
+    it("truncates results exceeding MAX_TOOL_RESULT_LENGTH", () => {
+      const longContent = "a".repeat(2000);
+      const messages: any[] = [
+        {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "x", content: longContent },
+          ],
+        },
+      ];
+      const result = _testOnly.truncateToolResults(messages);
+      const truncated = (result[0].content as any[])[0].content;
+      expect(truncated.length).toBeLessThan(longContent.length);
+      expect(truncated).toContain("… [truncated]");
+    });
+
+    it("passes through string-content messages unchanged", () => {
+      const messages: any[] = [
+        { role: "user", content: "just text" },
+      ];
+      const result = _testOnly.truncateToolResults(messages);
+      expect(result[0].content).toBe("just text");
+    });
+  });
+
+  describe("trimToValidBoundaries", () => {
+    it("trims orphaned tool_result from the start", () => {
+      const messages: any[] = [
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "x", content: "r" }] },
+        { role: "assistant", content: "text" },
+        { role: "user", content: "real user message" },
+        { role: "assistant", content: "real reply" },
+      ];
+      const result = _testOnly.trimToValidBoundaries(messages);
+      expect(result).toHaveLength(2);
+      expect(result[0].content).toBe("real user message");
+    });
+
+    it("trims orphaned tool_use from the end", () => {
+      const messages: any[] = [
+        { role: "user", content: "question" },
+        { role: "assistant", content: "answer" },
+        { role: "user", content: "follow-up" },
+        { role: "assistant", content: [{ type: "tool_use", id: "x", name: "t", input: {} }] },
+      ];
+      const result = _testOnly.trimToValidBoundaries(messages);
+      expect(result).toHaveLength(2);
+      expect(result[1].content).toBe("answer");
+    });
+
+    it("returns empty for all-orphaned messages", () => {
+      const messages: any[] = [
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "x", content: "r" }] },
+        { role: "assistant", content: [{ type: "tool_use", id: "x", name: "t", input: {} }] },
+      ];
+      const result = _testOnly.trimToValidBoundaries(messages);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("reconstructTurns", () => {
+    it("groups simple messages into turns", () => {
+      const messages: any[] = [
+        { role: "user", content: "Hi" },
+        { role: "assistant", content: "Hello" },
+        { role: "user", content: "Bye" },
+        { role: "assistant", content: "See ya" },
+      ];
+      const turns = _testOnly.reconstructTurns(messages);
+      expect(turns).toHaveLength(2);
+      expect(turns[0]).toHaveLength(2);
+      expect(turns[1]).toHaveLength(2);
+    });
+
+    it("groups tool exchanges within a turn", () => {
+      const messages: any[] = [
+        { role: "user", content: "Create card" },
+        { role: "assistant", content: [{ type: "tool_use", id: "t1", name: "create", input: {} }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "t1", content: "ok" }] },
+        { role: "assistant", content: "Done" },
+        { role: "user", content: "Thanks" },
+        { role: "assistant", content: "Welcome" },
+      ];
+      const turns = _testOnly.reconstructTurns(messages);
+      expect(turns).toHaveLength(2);
+      expect(turns[0]).toHaveLength(4); // user, tool_use, tool_result, text
+      expect(turns[1]).toHaveLength(2); // user, text
+    });
   });
 });

--- a/src/agent/conversation-history.ts
+++ b/src/agent/conversation-history.ts
@@ -2,31 +2,157 @@ import type Anthropic from "@anthropic-ai/sdk";
 import { eq, desc } from "drizzle-orm";
 import { db, schema, sqlite } from "../db/client.js";
 
-const MAX_MESSAGES = 20;
+/**
+ * Maximum individual messages kept in the sliding window.
+ * A tool-heavy turn uses ~4-6 messages, so 40 gives ~6-10 tool turns
+ * or 20 simple text-only turns.
+ */
+const MAX_MESSAGES = 40;
 const TTL_MS = 30 * 60 * 1000; // 30 minutes
 
+/** Maximum length for tool_result content blocks stored in DB. */
+const MAX_TOOL_RESULT_LENGTH = 1500;
+
+/**
+ * In-memory history tracks complete turns (each sub-array is one user→response cycle).
+ * getHistory() flattens turns for the Claude API.
+ */
 interface ChatHistory {
-  messages: Anthropic.Messages.MessageParam[];
+  turns: Anthropic.Messages.MessageParam[][];
   lastActivity: number;
 }
 
 /** In-memory L1 cache — fast path for hot conversations. */
 const histories = new Map<number, ChatHistory>();
 
+// ---------------------------------------------------------------------------
+// Serialization helpers
+// ---------------------------------------------------------------------------
+
 /**
- * Extract string content from a MessageParam.
- * String content passes through; array content is JSON-serialized (defensive).
+ * Serialize message content for DB storage.
+ * String content passes through; array content (tool_use, tool_result blocks)
+ * is JSON-serialized.
  */
-function extractContent(content: Anthropic.Messages.MessageParam["content"]): string {
+function serializeContent(content: Anthropic.Messages.MessageParam["content"]): string {
   if (typeof content === "string") return content;
   return JSON.stringify(content);
 }
 
 /**
- * Load conversation from DB, respecting TTL.
- * Returns messages in chronological order, or empty array if expired/missing.
+ * Deserialize content loaded from DB back to its original type.
+ * Plain text passes through unchanged. JSON arrays (tool blocks) are parsed back.
+ * Backward compatible with existing plain-text rows.
  */
-function loadFromDb(chatId: number): Anthropic.Messages.MessageParam[] {
+function deserializeContent(raw: string): string | Anthropic.Messages.ContentBlockParam[] {
+  if (!raw.startsWith("[")) return raw;
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : raw;
+  } catch {
+    return raw;
+  }
+}
+
+/**
+ * Truncate tool_result content blocks that exceed MAX_TOOL_RESULT_LENGTH.
+ * Only affects the copy written to DB — the current turn keeps full results.
+ */
+function truncateToolResults(
+  messages: Anthropic.Messages.MessageParam[],
+): Anthropic.Messages.MessageParam[] {
+  return messages.map((msg) => {
+    if (typeof msg.content === "string") return msg;
+
+    const content = (msg.content as Anthropic.Messages.ContentBlockParam[]).map((block) => {
+      if (
+        block.type === "tool_result" &&
+        typeof block.content === "string" &&
+        block.content.length > MAX_TOOL_RESULT_LENGTH
+      ) {
+        return {
+          ...block,
+          content: block.content.slice(0, MAX_TOOL_RESULT_LENGTH) + "… [truncated]",
+        };
+      }
+      return block;
+    });
+
+    return { ...msg, content };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Turn reconstruction (for DB loads)
+// ---------------------------------------------------------------------------
+
+/**
+ * Trim loaded messages to valid turn boundaries.
+ * - From the front: skip until the first user message with string content
+ *   (not a tool_result array — those are mid-turn continuations).
+ * - From the back: skip until the last assistant message with string content.
+ */
+function trimToValidBoundaries(
+  messages: Anthropic.Messages.MessageParam[],
+): Anthropic.Messages.MessageParam[] {
+  // Find first "real" user message (string content = start of a turn)
+  let start = 0;
+  while (start < messages.length) {
+    const msg = messages[start];
+    if (msg.role === "user" && typeof msg.content === "string") break;
+    start++;
+  }
+
+  // Find last assistant message with string content
+  let end = messages.length - 1;
+  while (end >= start) {
+    const msg = messages[end];
+    if (msg.role === "assistant" && typeof msg.content === "string") break;
+    end--;
+  }
+
+  if (start > end) return [];
+  return messages.slice(start, end + 1);
+}
+
+/**
+ * Group flat messages back into turns. A new turn starts at each user message
+ * with string content (as opposed to tool_result arrays which are mid-turn).
+ */
+function reconstructTurns(
+  messages: Anthropic.Messages.MessageParam[],
+): Anthropic.Messages.MessageParam[][] {
+  const turns: Anthropic.Messages.MessageParam[][] = [];
+  let current: Anthropic.Messages.MessageParam[] = [];
+
+  for (const msg of messages) {
+    // A user message with string content starts a new turn
+    if (msg.role === "user" && typeof msg.content === "string") {
+      if (current.length > 0) {
+        turns.push(current);
+      }
+      current = [msg];
+    } else {
+      current.push(msg);
+    }
+  }
+
+  if (current.length > 0) {
+    turns.push(current);
+  }
+
+  return turns;
+}
+
+// ---------------------------------------------------------------------------
+// DB operations
+// ---------------------------------------------------------------------------
+
+/**
+ * Load conversation from DB, respecting TTL.
+ * Deserializes JSON content blocks and trims to valid turn boundaries.
+ */
+function loadFromDb(chatId: number): Anthropic.Messages.MessageParam[][] {
   try {
     const conv = db
       .select()
@@ -43,7 +169,6 @@ function loadFromDb(chatId: number): Anthropic.Messages.MessageParam[] {
     if (Date.now() - lastActivity > TTL_MS) return [];
 
     // Load last MAX_MESSAGES messages, newest first, then reverse.
-    // Secondary sort by id ensures user→assistant ordering within same second.
     const rows = db
       .select()
       .from(schema.conversationMessages)
@@ -53,10 +178,14 @@ function loadFromDb(chatId: number): Anthropic.Messages.MessageParam[] {
       .all()
       .reverse();
 
-    return rows.map((row) => ({
+    const messages: Anthropic.Messages.MessageParam[] = rows.map((row) => ({
       role: row.role as "user" | "assistant",
-      content: row.content,
+      content: deserializeContent(row.content),
     }));
+
+    // Trim orphaned fragments at window boundaries, then group into turns
+    const trimmed = trimToValidBoundaries(messages);
+    return reconstructTurns(trimmed);
   } catch (err) {
     console.error(`[conversation-history] Failed to load from DB for chat ${chatId}:`, err);
     return [];
@@ -70,16 +199,19 @@ const trimStmt = sqlite.prepare(`
     AND id NOT IN (
       SELECT id FROM conversation_messages
       WHERE telegram_chat_id = ?
-      ORDER BY created_at DESC
+      ORDER BY created_at DESC, id DESC
       LIMIT ?
     )
 `);
 
-/** Write messages to DB and trim excess. */
+/**
+ * Write all messages from a turn to DB and trim excess.
+ * Each message's content is serialized — string content stays as-is,
+ * array content (tool blocks) is JSON-serialized.
+ */
 function writeToDb(
   chatId: number,
-  userContent: string,
-  assistantContent: string,
+  turnMessages: Anthropic.Messages.MessageParam[],
 ): void {
   try {
     const now = new Date();
@@ -97,13 +229,20 @@ function writeToDb(
       })
       .run();
 
-    // Insert both messages
-    db.insert(schema.conversationMessages)
-      .values([
-        { telegramChatId: chatId, role: "user", content: userContent, createdAt: now },
-        { telegramChatId: chatId, role: "assistant", content: assistantContent, createdAt: now },
-      ])
-      .run();
+    // Truncate large tool results before storing
+    const toStore = truncateToolResults(turnMessages);
+
+    // Insert all messages from the turn
+    const values = toStore.map((msg) => ({
+      telegramChatId: chatId,
+      role: msg.role,
+      content: serializeContent(msg.content),
+      createdAt: now,
+    }));
+
+    if (values.length > 0) {
+      db.insert(schema.conversationMessages).values(values).run();
+    }
 
     // Trim excess messages beyond the sliding window
     trimStmt.run(chatId, chatId, MAX_MESSAGES);
@@ -111,6 +250,10 @@ function writeToDb(
     console.error(`[conversation-history] Failed to write to DB for chat ${chatId}:`, err);
   }
 }
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
 
 /** Get conversation history for a chat. Cache-first, falls back to DB on miss. */
 export function getHistory(chatId: number): Anthropic.Messages.MessageParam[] {
@@ -121,43 +264,45 @@ export function getHistory(chatId: number): Anthropic.Messages.MessageParam[] {
       histories.delete(chatId);
       return [];
     }
-    return entry.messages;
+    return entry.turns.flat();
   }
 
   // Cache miss — try to reload from DB
-  const messages = loadFromDb(chatId);
-  if (messages.length > 0) {
-    histories.set(chatId, { messages, lastActivity: Date.now() });
+  const turns = loadFromDb(chatId);
+  if (turns.length > 0) {
+    histories.set(chatId, { turns, lastActivity: Date.now() });
   }
-  return messages;
+  return turns.flat();
 }
 
-/** Append a user message and assistant response to conversation history. */
+/**
+ * Append a complete turn to conversation history.
+ * A turn is the full message sequence for one user interaction:
+ * [user, assistant/tool_use, user/tool_result, ..., assistant/text]
+ */
 export function appendToHistory(
   chatId: number,
-  userMessage: Anthropic.Messages.MessageParam,
-  assistantMessage: Anthropic.Messages.MessageParam,
+  turnMessages: Anthropic.Messages.MessageParam[],
 ): void {
   let entry = histories.get(chatId);
   if (!entry || Date.now() - entry.lastActivity > TTL_MS) {
-    entry = { messages: [], lastActivity: Date.now() };
+    entry = { turns: [], lastActivity: Date.now() };
   }
 
-  entry.messages.push(userMessage, assistantMessage);
+  entry.turns.push(turnMessages);
   entry.lastActivity = Date.now();
 
-  // Sliding window: keep last MAX_MESSAGES messages (always in user/assistant pairs)
-  while (entry.messages.length > MAX_MESSAGES) {
-    entry.messages.shift();
-    entry.messages.shift();
+  // Sliding window: evict oldest complete turns until under MAX_MESSAGES
+  let totalMessages = entry.turns.reduce((sum, turn) => sum + turn.length, 0);
+  while (totalMessages > MAX_MESSAGES && entry.turns.length > 1) {
+    const evicted = entry.turns.shift()!;
+    totalMessages -= evicted.length;
   }
 
   histories.set(chatId, entry);
 
   // Write-through to DB
-  const userContent = extractContent(userMessage.content);
-  const assistantContent = extractContent(assistantMessage.content);
-  writeToDb(chatId, userContent, assistantContent);
+  writeToDb(chatId, turnMessages);
 }
 
 /** Clear history for a chat (both cache and DB). */
@@ -185,3 +330,16 @@ setInterval(() => {
     }
   }
 }, 10 * 60 * 1000);
+
+// ---------------------------------------------------------------------------
+// Test-only exports
+// ---------------------------------------------------------------------------
+
+export const _testOnly = {
+  serializeContent,
+  deserializeContent,
+  truncateToolResults,
+  trimToValidBoundaries,
+  reconstructTurns,
+  MAX_TOOL_RESULT_LENGTH,
+};


### PR DESCRIPTION
## Summary
- Store full message sequences (tool_use/tool_result blocks) in conversation history instead of only the final text response
- Enables multi-turn agentic workflows — e.g. "create a card" → "assign it to @alice" now works because Claude sees the card's publicId from the prior tool result
- Turn-based sliding window evicts complete turns (never orphans tool_use without its tool_result)
- Backward compatible with existing plain-text DB rows — no schema migration needed

## Test plan
- [x] TypeScript typecheck passes (`npm run typecheck`)
- [x] All 89 tests pass (27 in conversation-history, up from 7)
- [x] New test cases: tool call round-trip, JSON serialization, DB reload deserialization, large tool result truncation, turn-based eviction, backward compatibility, boundary trimming
- [ ] Manual: create card via Gremlin, then say "assign it to @nick" → should reference card by publicId from tool history

🤖 Generated with [Claude Code](https://claude.com/claude-code)