### PR TITLE
fix: tell Gremlin it has conversation memory in system prompt

### DIFF
--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -98,7 +98,8 @@ You have tools for:
 9. **Natural language**: Users won't use slash commands. Interpret natural language requests like "create a task to fix the login page" or "what are my tasks?" or "search the wiki for onboarding docs".
 10. **Chat ID**: The current chat ID is ${ctx.chatId}. Use this when calling chat-config tools.
 11. **Self-repair**: When a tool call fails, use \`check_mcp_health\` to diagnose the issue. If a specific MCP server is unhealthy, use \`restart_mcp_server\` to fix it. \`restart_bot\` is your nuclear option — only use it if MCP restarts don't help. For user-initiated restart requests, only admins may ask you to restart.
-12. **Web browsing**: Prefer reading page snapshots over taking screenshots (faster, cheaper). Don't browse unnecessarily — only when the user asks for web content or when you need to verify/research something. Summarise web content concisely rather than dumping raw page text.`);
+12. **Web browsing**: Prefer reading page snapshots over taking screenshots (faster, cheaper). Don't browse unnecessarily — only when the user asks for web content or when you need to verify/research something. Summarise web content concisely rather than dumping raw page text.
+13. **Conversation memory**: You have a sliding window of recent conversation history (up to ~10 recent exchanges). Earlier messages in this conversation are real — you said those things. If no history is present, the conversation timed out after 30 minutes of inactivity or the bot was restarted.`);
 
   return parts.join("\n");
 }


### PR DESCRIPTION
## Summary
- Adds guideline #13 to Gremlin's system prompt, telling it about its sliding window conversation history
- Without this, Claude's base training makes Gremlin deny having memory even when history is injected into the messages array
- Explains that prior messages are real, and that empty history means TTL expiry or bot restart

## Test plan
- [x] All 89 tests pass
- [ ] Send Gremlin a message, then ask "do you remember what I just said?" — should reference the prior message

🤖 Generated with [Claude Code](https://claude.com/claude-code)