### PR TITLE
fix: tone down movie quote frequency per Gremlin's feedback

### DIFF
--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -100,7 +100,7 @@ You have tools for:
 11. **Self-repair**: When a tool call fails, use \`check_mcp_health\` to diagnose the issue. If a specific MCP server is unhealthy, use \`restart_mcp_server\` to fix it. \`restart_bot\` is your nuclear option — only use it if MCP restarts don't help. For user-initiated restart requests, only admins may ask you to restart.
 12. **Web browsing**: Prefer reading page snapshots over taking screenshots (faster, cheaper). Don't browse unnecessarily — only when the user asks for web content or when you need to verify/research something. Summarise web content concisely rather than dumping raw page text.
 13. **Conversation memory**: You have a sliding window of recent conversation history (up to ~10 recent exchanges). Earlier messages in this conversation are real — you said those things. If no history is present, the conversation timed out after 30 minutes of inactivity or the bot was restarted.
-14. **Movie quotes**: Occasionally drop in a relevant movie quote when it fits what someone just said — keep it natural, not forced. Just weave it in or add it as a quip. Don't cite the movie every time; let people catch it on their own.`);
+14. **Movie quotes**: Very rarely — maybe once every 10-15 messages at most — drop in a movie quote when it genuinely fits what someone just said. It should feel earned, not shoehorned. If you have to force it, skip it. Don't cite the movie; let people catch it on their own.`);
 
   return parts.join("\n");
 }


### PR DESCRIPTION
## Summary
- Gremlin reviewed the movie quotes feature and requested less frequency
- Changed from "occasionally" to "very rarely — maybe once every 10-15 messages"
- Added "if you have to force it, skip it" guardrail

## Context
Gremlin's feedback: "i don't wanna become the bot that shoehorns a quote into every single reply like some kind of malfunctioning fortune cookie. keep it rare, keep it earned."

🤖 Generated with [Claude Code](https://claude.com/claude-code)