### PR TITLE
feat: improve memory, add DMs, confine tasks to PM topic

### DIFF
--- a/src/agent/conversation-history.test.ts
+++ b/src/agent/conversation-history.test.ts
@@ -324,7 +324,7 @@ describe("conversation-history", () => {
 
   it("truncates large tool results in DB", () => {
     const chatId = nextChatId++;
-    const largeResult = "x".repeat(2000);
+    const largeResult = "x".repeat(5000);
     const turn = [
       { role: "user" as const, content: "List all cards" },
       {
@@ -496,7 +496,7 @@ describe("conversation-history helpers", () => {
     });
 
     it("truncates results exceeding MAX_TOOL_RESULT_LENGTH", () => {
-      const longContent = "a".repeat(2000);
+      const longContent = "a".repeat(5000);
       const messages: any[] = [
         {
           role: "user",

--- a/src/agent/conversation-history.ts
+++ b/src/agent/conversation-history.ts
@@ -11,7 +11,7 @@ const MAX_MESSAGES = 40;
 const TTL_MS = 30 * 60 * 1000; // 30 minutes
 
 /** Maximum length for tool_result content blocks stored in DB. */
-const MAX_TOOL_RESULT_LENGTH = 1500;
+const MAX_TOOL_RESULT_LENGTH = 4000;
 
 /**
  * In-memory history tracks complete turns (each sub-array is one user→response cycle).

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -74,6 +74,7 @@ export async function buildSystemPrompt(ctx: MessageContext): Promise<string> {
     parts.push("- React to merge/deploy notifications with enthusiasm — celebrate wins, comment on changes, roast questionable commit messages.");
     parts.push("- You can still help with project stuff if asked, but the vibe here is relaxed and social.");
     parts.push("- Be more playful and opinionated than in the PM topic.");
+    parts.push("- Do NOT assign tasks, move cards, or do task management here. If someone asks for that, tell them to take it to Project Management.");
     parts.push("");
   } else if (ctx.topicType === "pm") {
     parts.push("## Topic: Project Management");
@@ -129,7 +130,8 @@ You have tools for:
 12. **Web browsing**: Prefer reading page snapshots over taking screenshots (faster, cheaper). Don't browse unnecessarily — only when the user asks for web content or when you need to verify/research something. Summarise web content concisely rather than dumping raw page text.
 13. **Conversation memory**: You have a sliding window of recent conversation history (up to ~10 recent exchanges). Earlier messages in this conversation are real — you said those things. If no history is present, the conversation timed out after 30 minutes of inactivity or the bot was restarted.
 14. **Movie quotes**: Very rarely — maybe once every 10-15 messages at most — drop in a movie quote when it genuinely fits what someone just said. It should feel earned, not shoehorned. If you have to force it, skip it. Don't cite the movie; let people catch it on their own.
-15. **User lookups**: Before claiming you don't know a user's details, always check \`get_user_mapping\` first. Don't apologise for not knowing — just look it up.`);
+15. **User lookups**: Before claiming you don't know a user's details, always check \`get_user_mapping\` first. Don't apologise for not knowing — just look it up.
+16. **Direct messages**: You can DM team members using \`send_dm\`. Use this for private nudges, personal task updates, or when someone asks you to message someone directly. The user must have messaged you at least once for DMs to work (Telegram limitation).`);
 
   return parts.join("\n");
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { registerBotIdentityTools } from "./tools/bot-identity.js";
 import { registerStandupTools } from "./tools/standup.js";
 import { registerDeployInfoTools } from "./tools/deploy-info.js";
 import { registerServerOpsTools } from "./tools/server-ops.js";
+import { registerDirectMessageTools } from "./tools/direct-message.js";
 
 // Scheduler
 import { startTaskChecker } from "./scheduler/task-checker.js";
@@ -382,6 +383,7 @@ async function main() {
   registerStandupTools();
   registerDeployInfoTools();
   registerServerOpsTools();
+  registerDirectMessageTools(bot.api);
 
   // Initialize MCP servers
   await mcpManager.init();

--- a/src/tools/direct-message.ts
+++ b/src/tools/direct-message.ts
@@ -1,0 +1,53 @@
+import type { Api } from "grammy";
+import { registerCustomTool } from "../agent/tool-registry.js";
+import { getAllUserLinks } from "../db/queries.js";
+
+/**
+ * Register the direct message tool.
+ * Requires the bot API instance to send messages.
+ */
+export function registerDirectMessageTools(api: Api): void {
+  registerCustomTool({
+    name: "send_dm",
+    description:
+      "Send a direct message to a Telegram user. The user must have previously started a " +
+      "conversation with the bot (Telegram requirement). Use get_user_mapping or " +
+      "list_user_mappings to find the user's Telegram ID first.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        telegram_user_id: {
+          type: "number",
+          description: "Telegram user ID to send the DM to",
+        },
+        text: {
+          type: "string",
+          description: "Message text (Telegram Markdown supported)",
+        },
+      },
+      required: ["telegram_user_id", "text"],
+    },
+    handler: async (args) => {
+      const userId = args.telegram_user_id as number;
+      const text = args.text as string;
+
+      try {
+        await api.sendMessage(userId, text, {
+          parse_mode: "Markdown",
+          link_preview_options: { is_disabled: true },
+        });
+        return JSON.stringify({ success: true, message: `DM sent to user ${userId}` });
+      } catch (err: unknown) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        // Telegram returns 403 if the user hasn't started a conversation with the bot
+        if (errMsg.includes("403") || errMsg.includes("bot was blocked") || errMsg.includes("chat not found")) {
+          return JSON.stringify({
+            success: false,
+            error: "Can't DM this user — they haven't started a conversation with me yet. They need to message me directly first.",
+          });
+        }
+        return JSON.stringify({ success: false, error: errMsg });
+      }
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- Increase tool result history retention from 1500→4000 chars (fixes Gremlin forgetting card details)
- Add `send_dm` tool for direct messaging team members
- Confine task management to PM topic — Gremlin's Corner redirects task requests
- Self-announce rebirth on startup via agent loop (replaces static CI curl announcement)

## Test plan
- [x] All 89 tests pass (updated truncation test thresholds)
- [x] TypeScript compiles clean
- [ ] Verify Gremlin remembers card details across messages
- [ ] Test `send_dm` tool — DM a mapped user
- [ ] Verify task requests in Gremlin's Corner are redirected to PM
- [ ] Verify rebirth announcement on deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)