### PR TITLE
chore: rename xdeca-pm-bot to gremlin

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,7 +59,7 @@ jobs:
           rsync -avz \
             -e "ssh -i ~/.ssh/deploy_key" \
             deploy/docker-compose.yml .env \
-            ubuntu@${{ secrets.DEPLOY_HOST }}:~/apps/xdeca-pm-bot/
+            ubuntu@${{ secrets.DEPLOY_HOST }}:~/apps/gremlin/
 
       - name: Deploy source
         run: |
@@ -72,25 +72,25 @@ jobs:
             --exclude .github \
             -e "ssh -i ~/.ssh/deploy_key" \
             ./ \
-            ubuntu@${{ secrets.DEPLOY_HOST }}:~/apps/xdeca-pm-bot/src/
+            ubuntu@${{ secrets.DEPLOY_HOST }}:~/apps/gremlin/src/
 
       - name: Build and restart
         run: |
           ssh -i ~/.ssh/deploy_key ubuntu@${{ secrets.DEPLOY_HOST }} \
-            'cd ~/apps/xdeca-pm-bot && docker compose build --pull && docker compose up -d'
+            'cd ~/apps/gremlin && docker compose build --pull && docker compose up -d'
 
       - name: Verify deployment
         run: |
           for i in $(seq 1 6); do
             STATUS=$(ssh -i ~/.ssh/deploy_key ubuntu@${{ secrets.DEPLOY_HOST }} \
-              'docker inspect --format="{{ .State.Status }}" xdeca-pm-bot')
+              'docker inspect --format="{{ .State.Status }}" gremlin')
             echo "Attempt $i: container status=$STATUS"
             [ "$STATUS" = "running" ] && exit 0
             sleep 5
           done
           echo "::error::Container is not running after 30s! Dumping logs:"
           ssh -i ~/.ssh/deploy_key ubuntu@${{ secrets.DEPLOY_HOST }} \
-            'docker logs --tail 50 xdeca-pm-bot'
+            'docker logs --tail 50 gremlin'
           exit 1
 
       - name: Announce failed rebirth

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# xdeca-pm-bot
+# gremlin
 
 Telegram bot for Kan.bn task management — full LLM agent with MCP tools. TypeScript + Grammy + Claude Haiku + SQLite (Drizzle ORM).
 
@@ -43,13 +43,13 @@ Telegram Message → Grammy → Agent Loop (Claude Haiku + tools) → Response �
 
 ## Deployment
 
-This is the source code only. Deployment config is in `xdeca-infra/xdeca-pm-bot/`:
+This is the source code only. Deployment config is in `xdeca-infra/gremlin/`:
 
-- `docker-compose.yml` builds from this source (rsynced from `xdeca-pm-bot/` to `xdeca-pm-bot/src/` on server)
+- `docker-compose.yml` builds from this source (rsynced from `gremlin/` to `gremlin/src/` on server)
 - Secrets in `secrets.yaml` (SOPS-encrypted)
-- Deploy: `./scripts/deploy-to.sh 34.116.110.7 xdeca-pm-bot` from xdeca-infra repo
+- Deploy: `./scripts/deploy-to.sh 34.116.110.7 gremlin` from xdeca-infra repo
 - Server: GCP Compute Engine (e2-medium) at 34.116.110.7
-- Logs: `ssh ubuntu@34.116.110.7 'docker logs -f xdeca-pm-bot'`
+- Logs: `ssh ubuntu@34.116.110.7 'docker logs -f gremlin'`
 
 ## Key Patterns
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# xdeca-pm-bot
+# gremlin
 
 Telegram bot for [Kan.bn](https://tasks.xdeca.com) task management — full LLM agent with MCP tools. TypeScript + [grammY](https://grammy.dev) + Claude Haiku + SQLite (Drizzle ORM).
 
@@ -83,14 +83,14 @@ npm run test:coverage # Coverage report
 
 ## Deployment
 
-Source code only — deployment config lives in [xdeca-infra](https://github.com/10xdeca/xdeca-infra) under `xdeca-pm-bot/`.
+Source code only — deployment config lives in [xdeca-infra](https://github.com/10xdeca/xdeca-infra) under `gremlin/`.
 
 ```bash
 # From xdeca-infra repo:
-./scripts/deploy-to.sh 34.116.110.7 xdeca-pm-bot
+./scripts/deploy-to.sh 34.116.110.7 gremlin
 ```
 
-Secrets are managed via SOPS in `xdeca-infra/xdeca-pm-bot/secrets.yaml`.
+Secrets are managed via SOPS in `xdeca-infra/gremlin/secrets.yaml`.
 
 ## Project Structure
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,9 +1,9 @@
 services:
-  xdeca-pm-bot:
+  gremlin:
     build:
       context: ./src
       dockerfile: Dockerfile
-    container_name: xdeca-pm-bot
+    container_name: gremlin
     restart: unless-stopped
     environment:
       - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
@@ -20,7 +20,7 @@ services:
       - REMINDER_INTERVAL_HOURS=${REMINDER_INTERVAL_HOURS:-1}
       - ADMIN_USER_IDS=${ADMIN_USER_IDS}
     volumes:
-      - xdeca_pm_bot_data:/app/data
+      - gremlin_data:/app/data
       - /var/run/docker.sock:/var/run/docker.sock
 
   survey:
@@ -40,4 +40,4 @@ services:
     command: ["npx", "tsx", "survey/server.ts"]
 
 volumes:
-  xdeca_pm_bot_data:
+  gremlin_data:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "xdeca-pm-bot",
+  "name": "gremlin",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "xdeca-pm-bot",
+      "name": "gremlin",
       "version": "1.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "xdeca-pm-bot",
+  "name": "gremlin",
   "version": "1.0.0",
   "description": "Telegram bot for Kan task management - chase people about overdue tasks",
   "type": "module",

--- a/src/agent/mcp-manager.ts
+++ b/src/agent/mcp-manager.ts
@@ -279,7 +279,7 @@ class McpManager {
       });
 
       const client = new Client({
-        name: `xdeca-pm-bot-${config.name}`,
+        name: `gremlin-${config.name}`,
         version: "1.0.0",
       });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -373,7 +373,7 @@ bot.catch((err) => {
 // --- Startup ---
 
 async function main() {
-  console.log("Starting xdeca-pm-bot (agent mode)...");
+  console.log("Starting Gremlin (agent mode)...");
 
   // Register custom tools
   registerChatConfigTools();

--- a/src/utils/docker.ts
+++ b/src/utils/docker.ts
@@ -12,7 +12,7 @@
 import http from "http";
 
 const DOCKER_SOCKET = "/var/run/docker.sock";
-const CONTAINER_NAME = "xdeca-pm-bot";
+const CONTAINER_NAME = "gremlin";
 
 /** Make an HTTP request to the Docker Engine API over the Unix socket. */
 function dockerRequest(

--- a/src/utils/sprint.test.ts
+++ b/src/utils/sprint.test.ts
@@ -66,12 +66,12 @@ describe("sprint utilities", () => {
   });
 
   describe("isMidSprintDay", () => {
-    it("returns true on day 7", () => {
-      expect(isMidSprintDay(new Date("2025-01-11T12:00:00Z"))).toBe(true);
+    it("returns true on day 8 (Sunday)", () => {
+      expect(isMidSprintDay(new Date("2025-01-12T12:00:00Z"))).toBe(true);
     });
 
     it("returns false on other days", () => {
-      expect(isMidSprintDay(new Date("2025-01-10T12:00:00Z"))).toBe(false);
+      expect(isMidSprintDay(new Date("2025-01-11T12:00:00Z"))).toBe(false);
     });
   });
 

--- a/src/utils/sprint.ts
+++ b/src/utils/sprint.ts
@@ -22,7 +22,7 @@ function getSprintEpoch(): Date {
  * Get the current day of the sprint (1-14)
  * Day 1 = Sunday (sprint start)
  * Day 2 = Monday
- * Day 7 = Saturday (mid-sprint)
+ * Day 8 = Sunday (mid-sprint)
  * Day 13 = Friday (sprint end)
  * Day 14 = Saturday (break day)
  */
@@ -49,10 +49,10 @@ export function isSprintPlanningWindow(now: Date = new Date()): boolean {
 }
 
 /**
- * Check if it's the mid-sprint day (Saturday, day 7)
+ * Check if it's the mid-sprint day (Sunday, day 8)
  */
 export function isMidSprintDay(now: Date = new Date()): boolean {
-  return getSprintDay(now) === 7;
+  return getSprintDay(now) === 8;
 }
 
 /**
@@ -83,7 +83,7 @@ export function getSprintInfo(now: Date = new Date()): {
   return {
     day,
     isPlanningWindow: day <= 2,
-    isMidSprint: day === 7,
+    isMidSprint: day === 8,
     isSprintEnd: day === 13,
     isBreak: day === 14,
   };


### PR DESCRIPTION
## Summary
- Rename all references from `xdeca-pm-bot` to `gremlin` across source, Docker, CI, and docs
- Fix mid-sprint day from Saturday (day 7) to Sunday (day 8) — closes #23

## Server Migration Required

**Before merging**, the server needs to be migrated:

```bash
# On 34.116.110.7:
docker compose -f ~/apps/xdeca-pm-bot/docker-compose.yml down
mv ~/apps/xdeca-pm-bot ~/apps/gremlin

# Copy volume data (preserves SQLite DB)
docker volume create gremlin_data
docker run --rm \
  -v xdeca_pm_bot_data:/from \
  -v gremlin_data:/to \
  alpine sh -c 'cp -a /from/. /to/'
```

Then merge this PR — the deploy will pick up the new paths.

## Files changed
- `package.json` — name field
- `deploy/docker-compose.yml` — service, container, volume names
- `.github/workflows/deploy.yml` — server paths, Docker commands
- `src/utils/docker.ts` — container name constant
- `src/agent/mcp-manager.ts` — MCP client name prefix
- `src/index.ts` — startup log
- `CLAUDE.md`, `README.md` — documentation
- `src/utils/sprint.ts` + tests — mid-sprint day fix

## Test plan
- [x] All 89 tests pass
- [x] TypeScript compiles clean
- [ ] Server migration completed before merge
- [ ] Deploy succeeds with new paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)