### PR TITLE
feat: add GitHub issue tools (create and list)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,7 @@ RADICALE_PASSWORD=                      # Radicale password (required to enable)
 # RADICALE_CALENDAR_OWNER=             # Optional: access another user's calendars
 
 # GitHub (code reading)
-GITHUB_TOKEN=                # Fine-grained PAT with contents:read scope
+GITHUB_TOKEN=                # Fine-grained PAT (contents:read+write, issues:write, pull_requests:write)
 # GITHUB_REPO=10xdeca/gremlin  # Default repo (owner/name)
 # GITHUB_BRANCH=main            # Default branch
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Telegram Message → Grammy → Agent Loop (Claude Sonnet + tools) → Response 
 ### Key Directories
 
 - `src/agent/` — Agent loop, MCP manager, tool registry, system prompt, conversation history
-- `src/tools/` — Custom tools (chat-config, user-mapping, sprint-info, bot-identity)
+- `src/tools/` — Custom tools (chat-config, user-mapping, sprint-info, bot-identity, github-repo, server-ops, deploy-info, direct-message, standup)
 - `src/scheduler/` — Cron-based reminder checks (uses MCP client directly, no LLM)
 - `src/services/` — Bot identity cache, vagueness evaluator
 - `src/db/` — Schema, queries, SQLite client
@@ -58,7 +58,7 @@ This is the source code only. Deployment config is in `xdeca-infra/gremlin/`:
 ## Key Patterns
 
 - ALL user messages (including /commands) route through the agent loop in `src/agent/agent-loop.ts`
-- The agent has access to ~60 MCP tools (Kan + Outline + Radicale) plus custom tools for DB config
+- The agent has access to ~88 MCP tools (Kan + Outline + Radicale + Playwright) plus custom tools for DB config, GitHub, and server ops
 - System prompt is context-aware: includes bot identity, workspace config, sprint status, team mappings, admin status
 - Scheduler uses MCP client directly (no LLM) for deterministic reminder checks
 - DB queries are async wrappers around synchronous Drizzle calls
@@ -106,8 +106,37 @@ See `.env.example` for all required and optional variables. Key additions for th
 - `RADICALE_USERNAME` — Radicale username
 - `RADICALE_PASSWORD` — Radicale password (required to enable Radicale MCP server)
 - `RADICALE_CALENDAR_OWNER` — Optional: access another user's calendars
-- `GITHUB_TOKEN` — Fine-grained PAT with `contents:read` scope (required to enable code reading tools)
+- `GITHUB_TOKEN` — Fine-grained PAT with `contents:read`, `issues:write`, `pull_requests:write` scopes (enables code reading, issue creation, PR creation tools)
 - `GITHUB_REPO` — Default repo for code reading (default: `10xdeca/gremlin`)
 - `PLAYWRIGHT_ENABLED` — Set to `"true"` to enable web browsing tools (Playwright MCP server)
 - `HEALTH_PORT` — Health check server port (default: 8080)
 - `DEPLOY_SHA` — Git SHA of deployed commit (set by CI)
+
+## Future Directions
+
+Planned capabilities and enhancements:
+
+### GitHub Integration (expand existing tools)
+- **Issue creation** — `create_github_issue` tool so Gremlin can file bugs/tasks directly from Telegram conversations
+- **PR creation** — read code → create branch → open PR workflow, all via GitHub REST API (no git binary needed)
+- PAT already has `contents:write`, `issues:write`, `pull_requests:write` scopes
+
+### Web Search
+- Gremlin can browse specific URLs (Playwright) but can't search the web
+- Add a lightweight search tool wrapping Brave Search API or SearXNG
+- Would make Gremlin significantly more capable for research tasks
+
+### Long-term Memory
+- Currently context resets after 30min TTL
+- Add persistent memory (similar to Claude Code's memory system) for team preferences, recurring topics, project context
+- Could use Outline wiki as backing store (already has MCP tools for it)
+
+### Proactive Insights
+- Gremlin already has scheduler infrastructure (cron for reminders, standups, calendar checks)
+- Extend to proactively surface: undeployed merges, stale sprint cards, upcoming deadlines
+- Use existing MCP tools (Kan, GitHub, Radicale) to gather data, scheduler to trigger checks
+
+### Multi-repo Awareness
+- GitHub tools already support any repo in the org via `repo` parameter
+- Gremlin could cross-reference code across `gremlin`, `mcp-servers`, `kan`, `xdeca-infra`
+- Combined with web search, becomes a genuinely useful research assistant from Telegram

--- a/src/tools/github-repo.ts
+++ b/src/tools/github-repo.ts
@@ -1,11 +1,12 @@
 /**
- * GitHub repository tools — read source code and browse files.
+ * GitHub repository tools — read code, browse files, manage issues.
  *
  * Gives the agent the ability to:
  * - Read any file from its own repo (or other org repos)
  * - List directory contents to navigate the codebase
+ * - Create and list GitHub issues
  *
- * Uses the GitHub REST API (Contents endpoint) with a fine-grained PAT.
+ * Uses the GitHub REST API with a fine-grained PAT.
  * No `gh` CLI needed — just fetch.
  */
 
@@ -22,7 +23,10 @@ const MAX_FILE_SIZE = 100_000;
 const API_BASE = "https://api.github.com";
 
 /** Make an authenticated GitHub API request. */
-async function ghFetch(path: string): Promise<Response> {
+async function ghFetch(
+  path: string,
+  options?: { method?: string; body?: Record<string, unknown> },
+): Promise<Response> {
   const headers: Record<string, string> = {
     Accept: "application/vnd.github.v3+json",
     "User-Agent": "gremlin-bot",
@@ -30,7 +34,14 @@ async function ghFetch(path: string): Promise<Response> {
   if (GITHUB_TOKEN) {
     headers.Authorization = `Bearer ${GITHUB_TOKEN}`;
   }
-  return fetch(`${API_BASE}${path}`, { headers });
+  if (options?.body) {
+    headers["Content-Type"] = "application/json";
+  }
+  return fetch(`${API_BASE}${path}`, {
+    method: options?.method || "GET",
+    headers,
+    ...(options?.body ? { body: JSON.stringify(options.body) } : {}),
+  });
 }
 
 /** Register all GitHub repository tools. */
@@ -95,6 +106,145 @@ export function registerGitHubRepoTools(): void {
         return content.slice(0, MAX_FILE_SIZE) + `\n\n[truncated — file is ${data.size} bytes, showing first ${MAX_FILE_SIZE}]`;
       }
       return content;
+    },
+  });
+
+  // --- create_github_issue ---
+  registerCustomTool({
+    name: "create_github_issue",
+    description:
+      "Create a new issue on a GitHub repository. " +
+      "Use this to file bugs, feature requests, or track tasks. " +
+      "Returns the issue number and URL.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        title: {
+          type: "string",
+          description: "Issue title",
+        },
+        body: {
+          type: "string",
+          description: "Issue body (supports GitHub Markdown)",
+        },
+        labels: {
+          type: "array",
+          items: { type: "string" },
+          description: "Labels to apply (e.g. ['bug', 'priority:high']). Labels must already exist on the repo.",
+        },
+        assignees: {
+          type: "array",
+          items: { type: "string" },
+          description: "GitHub usernames to assign",
+        },
+        repo: {
+          type: "string",
+          description: `Repository in owner/name format (default: ${DEFAULT_REPO})`,
+        },
+      },
+      required: ["title"],
+    },
+    handler: async (args) => {
+      const repo = String(args.repo || DEFAULT_REPO);
+      const payload: Record<string, unknown> = {
+        title: String(args.title),
+      };
+      if (args.body) payload.body = String(args.body);
+      if (Array.isArray(args.labels) && args.labels.length > 0) payload.labels = args.labels;
+      if (Array.isArray(args.assignees) && args.assignees.length > 0) payload.assignees = args.assignees;
+
+      const res = await ghFetch(`/repos/${repo}/issues`, {
+        method: "POST",
+        body: payload,
+      });
+
+      if (!res.ok) {
+        const errText = await res.text();
+        return `Failed to create issue: ${res.status} ${res.statusText}\n${errText}`;
+      }
+
+      const issue = await res.json() as { number: number; html_url: string; title: string };
+      return JSON.stringify({
+        success: true,
+        number: issue.number,
+        url: issue.html_url,
+        title: issue.title,
+      }, null, 2);
+    },
+  });
+
+  // --- list_github_issues ---
+  registerCustomTool({
+    name: "list_github_issues",
+    description:
+      "List issues on a GitHub repository. " +
+      "Useful for checking existing bugs, finding duplicates before creating new issues, " +
+      "or reviewing open work.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        state: {
+          type: "string",
+          description: "Filter by state: 'open', 'closed', or 'all' (default: 'open')",
+        },
+        labels: {
+          type: "string",
+          description: "Comma-separated label names to filter by (e.g. 'bug,priority:high')",
+        },
+        limit: {
+          type: "number",
+          description: "Max issues to return (default: 10, max: 30)",
+        },
+        repo: {
+          type: "string",
+          description: `Repository in owner/name format (default: ${DEFAULT_REPO})`,
+        },
+      },
+    },
+    handler: async (args) => {
+      const repo = String(args.repo || DEFAULT_REPO);
+      const state = String(args.state || "open");
+      const limit = Math.min(Number(args.limit) || 10, 30);
+      const params = new URLSearchParams({
+        state,
+        per_page: String(limit),
+        sort: "updated",
+        direction: "desc",
+      });
+      if (args.labels) params.set("labels", String(args.labels));
+
+      const res = await ghFetch(`/repos/${repo}/issues?${params}`);
+      if (!res.ok) {
+        return `GitHub API error: ${res.status} ${res.statusText}`;
+      }
+
+      const issues = await res.json() as Array<{
+        number: number; title: string; state: string;
+        html_url: string; labels: Array<{ name: string }>;
+        assignees: Array<{ login: string }>; created_at: string; updated_at: string;
+        pull_request?: unknown;
+      }>;
+
+      // Filter out pull requests (GitHub API returns PRs as issues)
+      const realIssues = issues.filter((i) => !i.pull_request);
+
+      if (realIssues.length === 0) {
+        return `No ${state} issues found${args.labels ? ` with labels: ${args.labels}` : ""} in ${repo}`;
+      }
+
+      const lines = realIssues.map((i) => {
+        const labels = i.labels.map((l) => l.name).join(", ");
+        const assignees = i.assignees.map((a) => a.login).join(", ");
+        return [
+          `#${i.number}: ${i.title}`,
+          `  State: ${i.state} | Updated: ${i.updated_at.slice(0, 10)}`,
+          labels ? `  Labels: ${labels}` : "",
+          assignees ? `  Assigned: ${assignees}` : "",
+          `  ${i.html_url}`,
+        ].filter(Boolean).join("\n");
+      });
+
+      return `${realIssues.length} issue(s) in ${repo}:\n\n${lines.join("\n\n")}`;
     },
   });
 


### PR DESCRIPTION
## Summary
- Adds `create_github_issue` tool — file bugs, feature requests, or tasks directly from Telegram
- Adds `list_github_issues` tool — check existing issues, find duplicates, review open work
- Extends `ghFetch` to support POST/PATCH methods with JSON bodies
- Filters out pull requests from issue listings (GitHub API returns PRs as issues)

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (all 76 tests)
- [ ] Manually test creating an issue via Telegram bot
- [ ] Manually test listing issues via Telegram bot

🤖 Generated with [Claude Code](https://claude.com/claude-code)